### PR TITLE
Rename to remove specific reference to JNBT

### DIFF
--- a/gui/src/main/java/org/enginehub/linbus/gui/javafx/MainSceneSetup.java
+++ b/gui/src/main/java/org/enginehub/linbus/gui/javafx/MainSceneSetup.java
@@ -256,7 +256,7 @@ public class MainSceneSetup {
         protected TreeItem<NbtTreeView.TagEntry> call() throws Exception {
             LinReadOptions.Builder options = LinReadOptions.builder();
             if (tryingLegacyCompat) {
-                options.allowJnbtStringEncoding(true);
+                options.allowNormalUtf8Encoding(true);
             }
             return NbtTreeView.loadTreeItem(path, options.build());
         }
@@ -289,9 +289,15 @@ public class MainSceneSetup {
             Alert alert = new Alert(Alert.AlertType.WARNING);
             alert.setTitle(LinBusGui.TITLE_BASE + " - Invalid File");
             alert.setHeaderText("File contained invalid modified UTF-8");
-            alert.setContentText("The file you tried to open contained invalid modified UTF-8, " +
-                "but may be a legacy JNBT file. Would you like to try opening it with JNBT compatibility?\n" +
-                "Saving the file will convert it to standard NBT format.");
+            alert.setContentText(
+                """
+                The file you tried to open contained invalid modified UTF-8, \
+                but may be valid with (non-standard) normal UTF-8.
+                Would you like to try opening it with that enabled?
+
+                Note: Saving the file will convert it to standard NBT format.
+                """
+            );
             alert.getButtonTypes().setAll(
                 ButtonType.YES,
                 ButtonType.NO

--- a/stream/src/main/java/org/enginehub/linbus/stream/LinReadOptions.java
+++ b/stream/src/main/java/org/enginehub/linbus/stream/LinReadOptions.java
@@ -37,24 +37,25 @@ public final class LinReadOptions {
      * Builder for {@link LinReadOptions}.
      */
     public static final class Builder {
-        private boolean allowJnbtStringEncoding = false;
+        private boolean allowNormalUtf8Encoding = false;
 
         private Builder() {
         }
 
         /**
-         * Set whether to allow the string encoding used by JNBT. It is not compliant with the NBT specification and
-         * uses normal UTF-8 encoding instead of the modified UTF-8 encoding of {@link java.io.DataInput}.
+         * Set whether to allow normal UTF-8 encoding instead of the modified UTF-8 encoding of
+         * {@link java.io.DataInput}.
          *
          * <p>
          * Note that this option will force checking the bytes to select the correct encoding, which will be slower.
+         * It will still accept the modified UTF-8 encoding, but will do its best to disallow mixed encodings.
          * </p>
          *
-         * @param allowJnbtStringEncoding whether to allow the string encoding used by JNBT
+         * @param allowNormalUtf8Encoding whether to allow normal UTF-8 string encoding
          * @return this builder
          */
-        public Builder allowJnbtStringEncoding(boolean allowJnbtStringEncoding) {
-            this.allowJnbtStringEncoding = allowJnbtStringEncoding;
+        public Builder allowNormalUtf8Encoding(boolean allowNormalUtf8Encoding) {
+            this.allowNormalUtf8Encoding = allowNormalUtf8Encoding;
             return this;
         }
 
@@ -70,33 +71,34 @@ public final class LinReadOptions {
         @Override
         public String toString() {
             return "LinReadOptions.Builder{" +
-                "allowJnbtStringEncoding=" + allowJnbtStringEncoding +
+                "allowNormalUtf8Encoding=" + allowNormalUtf8Encoding +
                 '}';
         }
     }
 
-    private final boolean allowJnbtStringEncoding;
+    private final boolean allowNormalUtf8Encoding;
 
     private LinReadOptions(Builder builder) {
-        this.allowJnbtStringEncoding = builder.allowJnbtStringEncoding;
+        this.allowNormalUtf8Encoding = builder.allowNormalUtf8Encoding;
     }
 
     /**
-     * {@return whether to allow the string encoding used by JNBT} It is not compliant with the NBT specification and
-     * uses normal UTF-8 encoding instead of the modified UTF-8 encoding of {@link java.io.DataInput}.
+     * {@return whether to allow normal UTF-8 encoding instead of the modified UTF-8 encoding of
+     * {@link java.io.DataInput}}
      *
      * <p>
      * Note that this option will force checking the bytes to select the correct encoding, which will be slower.
+     * It will still accept the modified UTF-8 encoding, but will do its best to disallow mixed encodings.
      * </p>
      */
-    public boolean allowJnbtStringEncoding() {
-        return allowJnbtStringEncoding;
+    public boolean allowNormalUtf8Encoding() {
+        return allowNormalUtf8Encoding;
     }
 
     @Override
     public String toString() {
         return "LinReadOptions{" +
-            "allowJnbtStringEncoding=" + allowJnbtStringEncoding +
+            "allowNormalUtf8Encoding=" + allowNormalUtf8Encoding +
             '}';
     }
 }

--- a/stream/src/main/java/org/enginehub/linbus/stream/impl/LinNbtReader.java
+++ b/stream/src/main/java/org/enginehub/linbus/stream/impl/LinNbtReader.java
@@ -248,8 +248,8 @@ public class LinNbtReader implements LinStream {
     public LinNbtReader(DataInput input, LinReadOptions options) {
         this.input = input;
         this.stateStack = new ArrayDeque<>(List.of(new State.Initial()));
-        // We only need to check strings if we're allowing JNBT encoding.
-        this.stringEncoding = options.allowJnbtStringEncoding()
+        // We only need to check strings if we're allowing normal UTF-8 encoding.
+        this.stringEncoding = options.allowNormalUtf8Encoding()
             ? StringEncoding.UNKNOWN : StringEncoding.MODIFIED_UTF_8;
     }
 

--- a/stream/src/test/java/org/enginehub/linbus/stream/JnbtCompatibilityIntegrationTest.java
+++ b/stream/src/test/java/org/enginehub/linbus/stream/JnbtCompatibilityIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JnbtCompatibilityIntegrationTest {
 
-    private static final LinReadOptions OPTIONS = LinReadOptions.builder().allowJnbtStringEncoding(true).build();
+    private static final LinReadOptions OPTIONS = LinReadOptions.builder().allowNormalUtf8Encoding(true).build();
 
     private static final String NULL_BYTE_TEST_STRING = "Null: \0";
     private static final String TWO_BYTE_TEST_STRING = "2-byte: Ø";
@@ -195,7 +195,7 @@ public class JnbtCompatibilityIntegrationTest {
         var tokens = ImmutableList.copyOf(
             LinBinaryIO.read(
                 new DataInputStream(new ByteArrayInputStream(bytes)),
-                LinReadOptions.builder().allowJnbtStringEncoding(true).build()
+                LinReadOptions.builder().allowNormalUtf8Encoding(true).build()
             ).asIterator()
         );
         assertThat(tokens).containsExactly(


### PR DESCRIPTION
This may be a common error in other NBT libraries as well.