### PR TITLE
Allow empty SNBT compounds using LinSnbtReader

### DIFF
--- a/format-snbt/src/main/java/org/enginehub/linbus/format/snbt/impl/reader/LinSnbtReader.java
+++ b/format-snbt/src/main/java/org/enginehub/linbus/format/snbt/impl/reader/LinSnbtReader.java
@@ -217,7 +217,6 @@ public class LinSnbtReader implements LinStream {
         var token = read().token();
         if (token instanceof SnbtToken.CompoundStart) {
             stateStack.addLast(new State.InCompound());
-            stateStack.addLast(new State.CompoundEntryName());
             tokenQueue.addLast(new LinToken.CompoundStart());
             return;
         }
@@ -237,8 +236,13 @@ public class LinSnbtReader implements LinStream {
     }
 
     private void advanceCompound() {
-        var token = read().token();
+        var typing = read();
+        var token = typing.token();
         switch (token) {
+            case SnbtToken.Text text -> {
+                readAgainStack.addLast(typing);
+                stateStack.addLast(new State.CompoundEntryName());
+            }
             case SnbtToken.CompoundEnd compoundEnd -> {
                 stateStack.removeLast();
                 tokenQueue.addLast(new LinToken.CompoundEnd());

--- a/format-snbt/src/main/java/org/enginehub/linbus/format/snbt/impl/reader/LinSnbtReader.java
+++ b/format-snbt/src/main/java/org/enginehub/linbus/format/snbt/impl/reader/LinSnbtReader.java
@@ -225,7 +225,6 @@ public class LinSnbtReader implements LinStream {
         var token = read().token();
         if (token instanceof SnbtToken.CompoundStart) {
             stateStack.addLast(State.InCompound.INSTANCE);
-            stateStack.addLast(State.CompoundEntryName.INSTANCE);
             tokenQueue.addLast(new LinToken.CompoundStart());
             return;
         }
@@ -245,8 +244,13 @@ public class LinSnbtReader implements LinStream {
     }
 
     private void advanceCompound() {
-        var token = read().token();
+        var typing = read();
+        var token = typing.token();
         switch (token) {
+            case SnbtToken.Text text -> {
+                readAgainStack.addLast(typing);
+                stateStack.addLast(State.CompoundEntryName.INSTANCE);
+            }
             case SnbtToken.CompoundEnd compoundEnd -> {
                 stateStack.removeLast();
                 tokenQueue.addLast(new LinToken.CompoundEnd());

--- a/format-snbt/src/test/java/org/enginehub/linbus/format/snbt/impl/reader/LinSnbtReaderTest.java
+++ b/format-snbt/src/test/java/org/enginehub/linbus/format/snbt/impl/reader/LinSnbtReaderTest.java
@@ -75,6 +75,27 @@ public class LinSnbtReaderTest {
     }
 
     @Test
+    void emptyRootCompound() {
+        var list = ImmutableList.copyOf(ezStringRead("{}").asIterator());
+        assertThat(list).containsExactly(new LinToken.CompoundStart(), new LinToken.CompoundEnd()).inOrder();
+
+        list = ImmutableList.copyOf(ezStringRead("{         }").asIterator());
+        assertThat(list).containsExactly(new LinToken.CompoundStart(), new LinToken.CompoundEnd()).inOrder();
+    }
+
+    @Test
+    void emptyNestedCompound() {
+        var list = ImmutableList.copyOf(ezStringRead("{nested:{}}").asIterator());
+        assertThat(list).containsExactly(
+            new LinToken.CompoundStart(),
+            new LinToken.Name("nested"),
+                new LinToken.CompoundStart(),
+                new LinToken.CompoundEnd(),
+            new LinToken.CompoundEnd()
+        ).inOrder();
+    }
+
+    @Test
     void simpleValueWithWhitespace() {
         var list = ImmutableList.copyOf(ezStringRead("{a:b      }").asIterator());
         assertThat(list).containsExactly(
@@ -168,7 +189,7 @@ public class LinSnbtReaderTest {
         var reader = ezStringRead("{;");
         assertThat(reader.nextOrNull()).isEqualTo(new LinToken.CompoundStart());
         var ex = assertThrows(NbtParseException.class, reader::nextOrNull);
-        assertThat(ex).hasMessageThat().isEqualTo(atCharacterIndex(1) + "Unexpected token: ';', expected Text");
+        assertThat(ex).hasMessageThat().isEqualTo(atCharacterIndex(1) + "Unexpected token: ';'");
     }
 
     @Test
@@ -186,7 +207,7 @@ public class LinSnbtReaderTest {
         assertThat(reader.nextOrNull()).isEqualTo(new LinToken.Name("a"));
         assertThat(reader.nextOrNull()).isEqualTo(new LinToken.String("@"));
         var ex = assertThrows(NbtParseException.class, reader::nextOrNull);
-        assertThat(ex).hasMessageThat().isEqualTo(atCharacterIndex(6) + "Unexpected token: Text[quoted=false, content=b]");
+        assertThat(ex).hasMessageThat().isEqualTo(atCharacterIndex(6) + "Unexpected end of input");
     }
 
     @Test


### PR DESCRIPTION
Not sure if it's "bad", that some error messages are now more generic (due to a broader set of allowed tokens). If it's "fixable", I'd change it.

(Not sure if that's the right way to do it either way)